### PR TITLE
Use correct function name in lgWordSize's error

### DIFF
--- a/src/Data/Bit/Utils.hs
+++ b/src/Data/Bit/Utils.hs
@@ -39,7 +39,7 @@ lgWordSize, wordSizeMask, wordSizeMaskC :: Int
 lgWordSize = case wordSize of
   32 -> 5
   64 -> 6
-  _  -> error "wordsToBytes: unknown architecture"
+  _  -> error "lgWordSize: unknown architecture"
 
 wordSizeMask = wordSize - 1
 wordSizeMaskC = complement wordSizeMask


### PR DESCRIPTION
Previously, it said `"wordsToBytes: unknown architecture"`, but I think this was intended to be `"lgWordSize: unknown architecture"`.