### PR TITLE
Support vector HEAD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist
 
 cabal.sandbox.config
 .cabal-sandbox
+dist-newstyle/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,15 @@
+packages: .
+
+tests: True
+
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/vector
+    tag: 532ba91ee81f6af2acc579c54058f5117b2e4326
+    subdir: vector
+    subdir: vector-stream
+
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/primitive
+    tag: 99ebd4b81ab320b71dcffd0c20082c5b2ccbcfee

--- a/src/Data/Bit/Internal.hs
+++ b/src/Data/Bit/Internal.hs
@@ -41,6 +41,7 @@ import Data.Typeable
 import qualified Data.Vector.Generic as V
 import qualified Data.Vector.Generic.Mutable as MV
 import qualified Data.Vector.Unboxed as U
+import Data.Vector.Internal.Check
 import GHC.Generics
 
 #ifdef BITVEC_THREADSAFE
@@ -438,7 +439,7 @@ unsafeFlipBit (BitMVec off _ arr) !i' = do
 -- [1,1,0,1]
 flipBit :: PrimMonad m => U.MVector (PrimState m) Bit -> Int -> m ()
 flipBit v i =
-  BOUNDS_CHECK(checkIndex) "flipBit" i (MV.length v) $
+  checkIndex Bounds i (MV.length v) $
     unsafeFlipBit v i
 {-# INLINE flipBit #-}
 
@@ -476,7 +477,7 @@ unsafeFlipBit (BitMVec off _ (MutableByteArray mba)) !i' = do
 -- [1,0,1]
 flipBit :: PrimMonad m => U.MVector (PrimState m) Bit -> Int -> m ()
 flipBit v i =
-  BOUNDS_CHECK(checkIndex) "flipBit" i (MV.length v) $ unsafeFlipBit v i
+  checkIndex Bounds i (MV.length v) $ unsafeFlipBit v i
 {-# INLINE flipBit #-}
 
 #endif


### PR DESCRIPTION
This PR adds support for `vector` HEAD which changed the `vector.h`

Fixes #56 

Relevant `vector` PR https://github.com/haskell/vector/pull/433

This *does not* do anything to support the old style of checking, so some CPP to select CPP is probably in order -_- Probably good to do after that `vector` gets a Hackage release.