### PR TITLE
Improve `gcdExt`

### DIFF
--- a/src/Data/Bit/F2Poly.hs
+++ b/src/Data/Bit/F2Poly.hs
@@ -328,7 +328,7 @@ toBigNat (ByteArray arr) = BN# arr
 -- >>> gcdExt 0b11 0b111
 -- (0b1,0b10)
 gcdExt :: F2Poly -> F2Poly -> (F2Poly, F2Poly)
-gcdExt = go 1 0
+gcdExt = go (F2Poly (U.singleton (Bit True))) (F2Poly U.empty) -- go 1 0
   where
     go s s' r r'
       | r' == 0   = (r, s)

--- a/src/Data/Bit/F2Poly.hs
+++ b/src/Data/Bit/F2Poly.hs
@@ -101,7 +101,7 @@ instance Num F2Poly where
   (-) = coerce xorBits
   negate = id
   abs    = id
-  signum = const (F2Poly (U.singleton (Bit True)))
+  signum = const (F2Poly $ castFromWords (U.singleton 1)) -- const 1
   (*) = coerce ((dropWhileEnd .) . karatsuba)
 #ifdef MIN_VERSION_ghc_bignum
   fromInteger !n = case n of
@@ -328,7 +328,7 @@ toBigNat (ByteArray arr) = BN# arr
 -- >>> gcdExt 0b11 0b111
 -- (0b1,0b10)
 gcdExt :: F2Poly -> F2Poly -> (F2Poly, F2Poly)
-gcdExt = go (F2Poly (U.singleton (Bit True))) (F2Poly U.empty) -- go 1 0
+gcdExt = go (F2Poly $ castFromWords (U.singleton 1)) (F2Poly U.empty) -- go 1 0
   where
     go s s' r r'
       | r' == 0   = (r, s)


### PR DESCRIPTION
Directly construct the 1 and 0 polynomials, instead of using `fromInteger`. This greatly reduces the amount of generated code and also makes the code a bit faster.