### PR TITLE
include Data.Bit.Gmp only if libgmp flag is set

### DIFF
--- a/bitvec.cabal
+++ b/bitvec.cabal
@@ -78,7 +78,6 @@ library
   other-modules:
     Data.Bit.F2Poly
     Data.Bit.F2PolyTS
-    Data.Bit.Gmp
     Data.Bit.Immutable
     Data.Bit.ImmutableTS
     Data.Bit.Internal
@@ -98,6 +97,8 @@ library
   if flag(libgmp)
     extra-libraries: gmp
     cpp-options: -DUseLibGmp
+    other-modules:
+      Data.Bit.Gmp
 
 test-suite bitvec-tests
   type: exitcode-stdio-1.0


### PR DESCRIPTION
If `Data.Bit.Gmp` module is linked into the library when the `libgmp` is not enabled, the resulting library will cause linking to fail on the missing symbols.

If GHC is built with the bignum-gmp (or prior to GHC 9, the integer-gmp) backend, then GMP will always be linked, so this issue can't be observed.

In order to reproduce the linking failure, you'll need to use a GHC with the bignum-native (or prior to GHC 9, the integer-simple) backend and then try to consume this library:

```
<no location info>: error:
    <command line>: /nix/store/0yxf15b6h4a0lxrx1d40zb1xv1zbp9h5-bitvec-lib-bitvec-1.1.3.0/lib/x86_64-linux-ghc-9.2.4/libHSbitvec-1.1.3.0-GZQucGlvw56FmFbfDZ6yWe-ghc9.2.4.so: undefined symbol: __gmpn_xnor_n
```