### PR TITLE
Use `HsFFI.h` types

### DIFF
--- a/cbits/bitvec_simd.c
+++ b/cbits/bitvec_simd.c
@@ -1,8 +1,10 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-size_t _hs_bitvec_popcount(const uint32_t *src, size_t len) {
-    size_t count = 0;
+#include "HsFFI.h"
+
+HsInt _hs_bitvec_popcount(const uint32_t *src, HsInt len) {
+    HsInt count = 0;
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         uint32_t x = src[i];
@@ -16,63 +18,63 @@ size_t _hs_bitvec_popcount(const uint32_t *src, size_t len) {
     return count;
 }
 
-void _hs_bitvec_com(uint8_t *dest, uint8_t *src, size_t len) {
+void _hs_bitvec_com(uint8_t *dest, uint8_t *src, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = ~src[i];
     }
 }
 
-void _hs_bitvec_and(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_and(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = src1[i] & src2[i];
     }
 }
 
-void _hs_bitvec_ior(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_ior(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = src1[i] | src2[i];
     }
 }
 
-void _hs_bitvec_xor(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_xor(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = src1[i] ^ src2[i];
     }
 }
 
-void _hs_bitvec_andn(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_andn(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = src1[i] & (~src2[i]);
     }
 }
 
-void _hs_bitvec_iorn(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_iorn(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = src1[i] | (~src2[i]);
     }
 }
 
-void _hs_bitvec_nand(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_nand(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = ~(src1[i] & src2[i]);
     }
 }
 
-void _hs_bitvec_nior(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_nior(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = ~(src1[i] | src2[i]);
     }
 }
 
-void _hs_bitvec_xnor(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, size_t len) {
+void _hs_bitvec_xnor(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, HsInt len) {
     #pragma omp simd
     for (size_t i = 0; i < len; i++) {
         dest[i] = ~(src1[i] ^ src2[i]);

--- a/src/Data/Bit/Immutable.hs
+++ b/src/Data/Bit/Immutable.hs
@@ -666,7 +666,7 @@ countBits :: U.Vector Bit -> Int
 countBits (BitVec _ 0 _)                      = 0
 #if UseSIMD
 countBits (BitVec 0 len arr) | modWordSize len == 0 =
-  fromIntegral (ompPopcount arr (len `shiftR` 5))
+  ompPopcount arr (len `shiftR` 5)
 #endif
 countBits (BitVec off len arr) | offBits == 0 = case modWordSize len of
   0    -> countBitsInWords (P.Vector offWords lWords arr)

--- a/src/Data/Bit/SIMD.hs
+++ b/src/Data/Bit/SIMD.hs
@@ -21,10 +21,10 @@ import GHC.Exts
 import System.IO.Unsafe
 
 foreign import ccall unsafe "_hs_bitvec_popcount"
-  omp_popcount :: ByteArray# -> Int# -> IO Word
+  omp_popcount :: ByteArray# -> Int# -> IO Int
 
 -- | SIMD optimized popcount. The length is in 32 bit words.
-ompPopcount :: ByteArray -> Int -> Word
+ompPopcount :: ByteArray -> Int -> Int
 ompPopcount (ByteArray arg#) (I# len#) =
   unsafeDupablePerformIO (omp_popcount arg# len#)
 {-# INLINE ompPopcount #-}


### PR DESCRIPTION
Use `HsFFI.h` types to ensure that the type signatures in `Data.Bit.SIMD` are correct.

<details><summary>If you're using VS Code</summary>

To get IntelliSense in `bitvec_simd.c` with the official C/C++ extension, run the `C/C++: Edit Configurations (UI)` command and add `~/.ghcup/ghc/9.6.1/lib/ghc-9.6.1/lib/x86_64-linux-ghc-9.6.1/rts-1.0.2/include/` (your path may ofc be a bit different) to the include path.

</details>