### PR TITLE
Add bang patterns to allow unboxing

### DIFF
--- a/src/Data/Bit/Internal.hs
+++ b/src/Data/Bit/Internal.hs
@@ -216,7 +216,7 @@ modifyByteArray (MutableByteArray mba) (I# ix) (W# msk) (W# new) = do
 
 -- | Write a word at the given bit offset in little-endian order (i.e., the LSB will correspond to the bit at the given address, the 2's bit will correspond to the address + 1, etc.).  If the offset is such that the word extends past the end of the vector, the word is truncated and as many low-order bits as possible are written.
 writeWord :: PrimMonad m => U.MVector (PrimState m) Bit -> Int -> Word -> m ()
-writeWord (BitMVec _ 0 _) _ _ = pure ()
+writeWord (BitMVec _ 0 _) !_ !_ = pure ()
 writeWord (BitMVec off len' arr) !i' !x
   | iMod == 0
   = if len >= i + wordSize


### PR DESCRIPTION
This allows unboxing of the `Int` and `Word` when calling `writeWord`.