### PR TITLE
Use SIMD intrinsics for `reverseBits`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
           echo "#define UNSAFE_CHECK(f) (\_ _ _ -> id)" >> src/vector.h
           ghc --make -Isrc:test -isrc:test -o Tests test/Main.hs +RTS -s
           ./Tests +RTS -s
+          ghc --make -Isrc:test -isrc:test -DUseSIMD -o Tests cbits/bitvec_simd.c test/Main.hs +RTS -s
+          ./Tests +RTS -s
 
   bounds-checking:
     needs: build

--- a/cbits/bitvec_simd.c
+++ b/cbits/bitvec_simd.c
@@ -1,6 +1,10 @@
 #include <inttypes.h>
 #include <stddef.h>
 
+#ifdef __x86_64__
+#include <immintrin.h>
+#endif
+
 #include "HsFFI.h"
 
 HsInt _hs_bitvec_popcount(const uint32_t *src, HsInt len) {
@@ -79,4 +83,105 @@ void _hs_bitvec_xnor(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, Hs
     for (size_t i = 0; i < len; i++) {
         dest[i] = ~(src1[i] ^ src2[i]);
     }
+}
+
+#ifdef __x86_64__
+static void reverse_bits_sse(uint32_t *dest, const uint32_t *src, HsInt len) {
+    __m128i mask1l  = _mm_set1_epi32(0x55555555);
+    __m128i mask1r  = _mm_set1_epi32(0xaaaaaaaa);
+    __m128i mask2l  = _mm_set1_epi32(0x33333333);
+    __m128i mask2r  = _mm_set1_epi32(0xcccccccc);
+    __m128i mask4l  = _mm_set1_epi32(0x0f0f0f0f);
+    __m128i mask4r  = _mm_set1_epi32(0xf0f0f0f0);
+    __m128i mask8l  = _mm_set1_epi32(0x00ff00ff);
+    __m128i mask8r  = _mm_set1_epi32(0xff00ff00);
+    __m128i mask16l = _mm_set1_epi32(0x0000ffff);
+    __m128i mask16r = _mm_set1_epi32(0xffff0000);
+
+    size_t i = 0;
+    for (; i < (len & (~0x3)); i += 4) {
+        __m128i x = _mm_loadu_si128((const __m128i *) (src + i));
+
+        // reverse each word
+        x = _mm_or_si128(_mm_slli_epi32(_mm_and_si128(x, mask1l),   1), _mm_srli_epi32(_mm_and_si128(x, mask1r),   1));
+        x = _mm_or_si128(_mm_slli_epi32(_mm_and_si128(x, mask2l),   2), _mm_srli_epi32(_mm_and_si128(x, mask2r),   2));
+        x = _mm_or_si128(_mm_slli_epi32(_mm_and_si128(x, mask4l),   4), _mm_srli_epi32(_mm_and_si128(x, mask4r),   4));
+        x = _mm_or_si128(_mm_slli_epi32(_mm_and_si128(x, mask8l),   8), _mm_srli_epi32(_mm_and_si128(x, mask8r),   8));
+        x = _mm_or_si128(_mm_slli_epi32(_mm_and_si128(x, mask16l), 16), _mm_srli_epi32(_mm_and_si128(x, mask16r), 16));
+
+        // reverse order of words
+        x = _mm_shuffle_epi32(x, 0x1b);
+
+        _mm_storeu_si128((__m128i *) (dest + len - 4 - i), x);
+    }
+    for (; i < len; i++) {
+        uint32_t x = src[i];
+        x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
+        x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
+        x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
+        x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
+        x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
+        dest[len - 1 - i] = x;
+    }
+}
+
+__attribute__((target("avx2")))
+static void reverse_bits_avx(uint32_t *dest, const uint32_t *src, HsInt len) {
+    __m256i mask1l  = _mm256_set1_epi32(0x55555555);
+    __m256i mask1r  = _mm256_set1_epi32(0xaaaaaaaa);
+    __m256i mask2l  = _mm256_set1_epi32(0x33333333);
+    __m256i mask2r  = _mm256_set1_epi32(0xcccccccc);
+    __m256i mask4l  = _mm256_set1_epi32(0x0f0f0f0f);
+    __m256i mask4r  = _mm256_set1_epi32(0xf0f0f0f0);
+    __m256i mask8l  = _mm256_set1_epi32(0x00ff00ff);
+    __m256i mask8r  = _mm256_set1_epi32(0xff00ff00);
+    __m256i mask16l = _mm256_set1_epi32(0x0000ffff);
+    __m256i mask16r = _mm256_set1_epi32(0xffff0000);
+
+    size_t i = 0;
+    for (; i < (len & (~0x7)); i += 8) {
+        __m256i x = _mm256_loadu_si256((const __m256i *) (src + i));
+
+        // reverse each word
+        x = _mm256_or_si256(_mm256_slli_epi32(_mm256_and_si256(x, mask1l),   1), _mm256_srli_epi32(_mm256_and_si256(x, mask1r),   1));
+        x = _mm256_or_si256(_mm256_slli_epi32(_mm256_and_si256(x, mask2l),   2), _mm256_srli_epi32(_mm256_and_si256(x, mask2r),   2));
+        x = _mm256_or_si256(_mm256_slli_epi32(_mm256_and_si256(x, mask4l),   4), _mm256_srli_epi32(_mm256_and_si256(x, mask4r),   4));
+        x = _mm256_or_si256(_mm256_slli_epi32(_mm256_and_si256(x, mask8l),   8), _mm256_srli_epi32(_mm256_and_si256(x, mask8r),   8));
+        x = _mm256_or_si256(_mm256_slli_epi32(_mm256_and_si256(x, mask16l), 16), _mm256_srli_epi32(_mm256_and_si256(x, mask16r), 16));
+
+        // reverse order of words
+        x = _mm256_permutevar8x32_epi32(x, _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0));
+
+        _mm256_storeu_si256((__m256i *) (dest + len - 8 - i), x);
+    }
+    for (; i < len; i++) {
+        uint32_t x = src[i];
+        x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
+        x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
+        x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
+        x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
+        x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
+        dest[len - 1 - i] = x;
+    }
+}
+#endif
+
+void _hs_bitvec_reverse_bits(uint32_t *dest, const uint32_t *src, HsInt len) {
+#ifdef __x86_64__
+    if (__builtin_cpu_supports("avx2")) {
+        reverse_bits_avx(dest, src, len);
+    } else {
+        reverse_bits_sse(dest, src, len);
+    }
+#else
+    for (size_t i = 0; i < len; i++) {
+        uint32_t x = src[i];
+        x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
+        x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
+        x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
+        x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
+        x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
+        dest[len - 1 - i] = x;
+    }
+#endif
 }

--- a/cbits/bitvec_simd.c
+++ b/cbits/bitvec_simd.c
@@ -86,7 +86,7 @@ void _hs_bitvec_xnor(uint8_t *dest, const uint8_t *src1, const uint8_t *src2, Hs
 }
 
 #ifdef __x86_64__
-static void reverse_bits_sse(uint32_t *dest, const uint32_t *src, HsInt len) {
+static void reverse_bits_sse(uint64_t *dest, const uint64_t *src, HsInt len) {
     __m128i mask1l  = _mm_set1_epi32(0x55555555);
     __m128i mask1r  = _mm_set1_epi32(0xaaaaaaaa);
     __m128i mask2l  = _mm_set1_epi32(0x33333333);
@@ -99,7 +99,7 @@ static void reverse_bits_sse(uint32_t *dest, const uint32_t *src, HsInt len) {
     __m128i mask16r = _mm_set1_epi32(0xffff0000);
 
     size_t i = 0;
-    for (; i < (len & (~0x3)); i += 4) {
+    for (; i < (len & (~0x1)); i += 2) {
         __m128i x = _mm_loadu_si128((const __m128i *) (src + i));
 
         // reverse each word
@@ -112,21 +112,22 @@ static void reverse_bits_sse(uint32_t *dest, const uint32_t *src, HsInt len) {
         // reverse order of words
         x = _mm_shuffle_epi32(x, 0x1b);
 
-        _mm_storeu_si128((__m128i *) (dest + len - 4 - i), x);
+        _mm_storeu_si128((__m128i *) (dest + len - 2 - i), x);
     }
     for (; i < len; i++) {
-        uint32_t x = src[i];
-        x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
-        x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
-        x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
-        x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
-        x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
+        uint64_t x = src[i];
+        x = ((x & 0x5555555555555555) <<  1) | ((x & 0xaaaaaaaaaaaaaaaa) >>  1);
+        x = ((x & 0x3333333333333333) <<  2) | ((x & 0xcccccccccccccccc) >>  2);
+        x = ((x & 0x0f0f0f0f0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0f0f0f0f0) >>  4);
+        x = ((x & 0x00ff00ff00ff00ff) <<  8) | ((x & 0xff00ff00ff00ff00) >>  8);
+        x = ((x & 0x0000ffff0000ffff) << 16) | ((x & 0xffff0000ffff0000) >> 16);
+        x = ((x & 0x00000000ffffffff) << 32) | ((x & 0xffffffff00000000) >> 32);
         dest[len - 1 - i] = x;
     }
 }
 
 __attribute__((target("avx2")))
-static void reverse_bits_avx(uint32_t *dest, const uint32_t *src, HsInt len) {
+static void reverse_bits_avx(uint64_t *dest, const uint64_t *src, HsInt len) {
     __m256i mask1l  = _mm256_set1_epi32(0x55555555);
     __m256i mask1r  = _mm256_set1_epi32(0xaaaaaaaa);
     __m256i mask2l  = _mm256_set1_epi32(0x33333333);
@@ -139,7 +140,7 @@ static void reverse_bits_avx(uint32_t *dest, const uint32_t *src, HsInt len) {
     __m256i mask16r = _mm256_set1_epi32(0xffff0000);
 
     size_t i = 0;
-    for (; i < (len & (~0x7)); i += 8) {
+    for (; i < (len & (~0x3)); i += 4) {
         __m256i x = _mm256_loadu_si256((const __m256i *) (src + i));
 
         // reverse each word
@@ -152,21 +153,22 @@ static void reverse_bits_avx(uint32_t *dest, const uint32_t *src, HsInt len) {
         // reverse order of words
         x = _mm256_permutevar8x32_epi32(x, _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0));
 
-        _mm256_storeu_si256((__m256i *) (dest + len - 8 - i), x);
+        _mm256_storeu_si256((__m256i *) (dest + len - 4 - i), x);
     }
     for (; i < len; i++) {
-        uint32_t x = src[i];
-        x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
-        x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
-        x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
-        x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
-        x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
+        uint64_t x = src[i];
+        x = ((x & 0x5555555555555555) <<  1) | ((x & 0xaaaaaaaaaaaaaaaa) >>  1);
+        x = ((x & 0x3333333333333333) <<  2) | ((x & 0xcccccccccccccccc) >>  2);
+        x = ((x & 0x0f0f0f0f0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0f0f0f0f0) >>  4);
+        x = ((x & 0x00ff00ff00ff00ff) <<  8) | ((x & 0xff00ff00ff00ff00) >>  8);
+        x = ((x & 0x0000ffff0000ffff) << 16) | ((x & 0xffff0000ffff0000) >> 16);
+        x = ((x & 0x00000000ffffffff) << 32) | ((x & 0xffffffff00000000) >> 32);
         dest[len - 1 - i] = x;
     }
 }
 #endif
 
-void _hs_bitvec_reverse_bits(uint32_t *dest, const uint32_t *src, HsInt len) {
+void _hs_bitvec_reverse_bits(HsWord *dest, const HsWord *src, HsInt len) {
 #ifdef __x86_64__
     if (__builtin_cpu_supports("avx2")) {
         reverse_bits_avx(dest, src, len);
@@ -174,14 +176,29 @@ void _hs_bitvec_reverse_bits(uint32_t *dest, const uint32_t *src, HsInt len) {
         reverse_bits_sse(dest, src, len);
     }
 #else
-    for (size_t i = 0; i < len; i++) {
-        uint32_t x = src[i];
-        x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
-        x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
-        x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
-        x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
-        x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
-        dest[len - 1 - i] = x;
+    if (sizeof(HsWord) == 8) {
+        // 64 bit
+        for (size_t i = 0; i < len; i++) {
+            uint64_t x = src[i];
+            x = ((x & 0x5555555555555555) <<  1) | ((x & 0xaaaaaaaaaaaaaaaa) >>  1);
+            x = ((x & 0x3333333333333333) <<  2) | ((x & 0xcccccccccccccccc) >>  2);
+            x = ((x & 0x0f0f0f0f0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0f0f0f0f0) >>  4);
+            x = ((x & 0x00ff00ff00ff00ff) <<  8) | ((x & 0xff00ff00ff00ff00) >>  8);
+            x = ((x & 0x0000ffff0000ffff) << 16) | ((x & 0xffff0000ffff0000) >> 16);
+            x = ((x & 0x00000000ffffffff) << 32) | ((x & 0xffffffff00000000) >> 32);
+            dest[len - 1 - i] = x;
+        }
+    } else {
+        // 32 bit
+        for (size_t i = 0; i < len; i++) {
+            uint32_t x = src[i];
+            x = ((x & 0x55555555) <<  1) | ((x & 0xaaaaaaaa) >>  1);
+            x = ((x & 0x33333333) <<  2) | ((x & 0xcccccccc) >>  2);
+            x = ((x & 0x0f0f0f0f) <<  4) | ((x & 0xf0f0f0f0) >>  4);
+            x = ((x & 0x00ff00ff) <<  8) | ((x & 0xff00ff00) >>  8);
+            x = ((x & 0x0000ffff) << 16) | ((x & 0xffff0000) >> 16);
+            dest[len - 1 - i] = x;
+        }
     }
 #endif
 }

--- a/src/Data/Bit/Immutable.hs
+++ b/src/Data/Bit/Immutable.hs
@@ -449,6 +449,13 @@ excludeBits is xs = runST $ do
 --
 -- @since 1.0.1.0
 reverseBits :: U.Vector Bit -> U.Vector Bit
+#ifdef UseSIMD
+reverseBits (BitVec 0 len arr) | modWordSize len == 0 = runST $ do
+  let n = len `shiftR` 5 -- length in 32 bit words
+  marr <- newByteArray (n `shiftL` 2)
+  reverseBitsC marr arr n
+  BitVec 0 len <$> unsafeFreezeByteArray marr
+#endif
 reverseBits xs = runST $ do
   let n    = U.length xs
   ys <- MU.new n

--- a/src/Data/Bit/Immutable.hs
+++ b/src/Data/Bit/Immutable.hs
@@ -451,9 +451,8 @@ excludeBits is xs = runST $ do
 reverseBits :: U.Vector Bit -> U.Vector Bit
 #ifdef UseSIMD
 reverseBits (BitVec 0 len arr) | modWordSize len == 0 = runST $ do
-  let n = len `shiftR` 5 -- length in 32 bit words
-  marr <- newByteArray (n `shiftL` 2)
-  reverseBitsC marr arr n
+  marr <- newByteArray (len `shiftR` 3)
+  reverseBitsC marr arr (divWordSize len)
   BitVec 0 len <$> unsafeFreezeByteArray marr
 #endif
 reverseBits xs = runST $ do

--- a/src/Data/Bit/SIMD.hs
+++ b/src/Data/Bit/SIMD.hs
@@ -123,7 +123,7 @@ ompXnor (MutableByteArray res#) (ByteArray arg1#) (ByteArray arg2#) (I# len#) =
 foreign import ccall unsafe "_hs_bitvec_reverse_bits"
   reverse_bits :: MutableByteArray# s -> ByteArray# -> Int# -> IO ()
 
--- | The length is in 32 bit words.
+-- | The length is in words.
 reverseBitsC :: MutableByteArray s -> ByteArray -> Int -> ST s ()
 reverseBitsC (MutableByteArray res#) (ByteArray arg#) (I# len#) =
   unsafeIOToST (reverse_bits res# arg# len#)

--- a/src/Data/Bit/SIMD.hs
+++ b/src/Data/Bit/SIMD.hs
@@ -12,6 +12,7 @@ module Data.Bit.SIMD
   , ompNand
   , ompNior
   , ompXnor
+  , reverseBitsC
   ) where
 
 import Control.Monad.ST
@@ -118,3 +119,12 @@ ompXnor :: MutableByteArray s -> ByteArray -> ByteArray -> Int -> ST s ()
 ompXnor (MutableByteArray res#) (ByteArray arg1#) (ByteArray arg2#) (I# len#) =
   unsafeIOToST (omp_xnor res# arg1# arg2# len#)
 {-# INLINE ompXnor #-}
+
+foreign import ccall unsafe "_hs_bitvec_reverse_bits"
+  reverse_bits :: MutableByteArray# s -> ByteArray# -> Int# -> IO ()
+
+-- | The length is in 32 bit words.
+reverseBitsC :: MutableByteArray s -> ByteArray -> Int -> ST s ()
+reverseBitsC (MutableByteArray res#) (ByteArray arg#) (I# len#) =
+  unsafeIOToST (reverse_bits res# arg# len#)
+{-# INLINE reverseBitsC #-}

--- a/test/Tests/SetOps.hs
+++ b/test/Tests/SetOps.hs
@@ -41,7 +41,7 @@ setOpTests = testGroup "Set operations"
   , testProperty "invertInPlace middle"     prop_invertInPlace_middle
   , testProperty "invertInPlaceLong middle" prop_invertInPlaceLong_middle
 
-  , localOption (QuickCheckTests 500) $ mkGroup "reverseBits" prop_reverseBits
+  , adjustOption (\n -> max 500 n :: QuickCheckTests) $ mkGroup "reverseBits" prop_reverseBits
 
   , testProperty "reverseInPlace"            prop_reverseInPlace
   , testProperty "reverseInPlaceWords"       prop_reverseInPlaceWords

--- a/test/Tests/SetOps.hs
+++ b/test/Tests/SetOps.hs
@@ -41,7 +41,7 @@ setOpTests = testGroup "Set operations"
   , testProperty "invertInPlace middle"     prop_invertInPlace_middle
   , testProperty "invertInPlaceLong middle" prop_invertInPlaceLong_middle
 
-  , mkGroup "reverseBits" prop_reverseBits
+  , localOption (QuickCheckTests 500) $ mkGroup "reverseBits" prop_reverseBits
 
   , testProperty "reverseInPlace"            prop_reverseInPlace
   , testProperty "reverseInPlaceWords"       prop_reverseInPlaceWords


### PR DESCRIPTION
Refs #66.

There are three C implementations:

* an SSE version (only uses SSE2)
* an AVX version (uses AVX2)
* a pure C version

The SIMD versions are behind an `#ifdef __x86_64__` (which is defined by both gcc and clang) and the specific version is selected via `__builtin_cpu_supports` (which is again defined by both gcc and clang).

I increased the number of `reverseBits` tests to 500, to make it more likely to catch errors in the C implementation (I intentionally introduced some bugs and some would only show up after a few runs of the test suite, with the default 100 tests).

<details><summary>Benchmark results (with #70)</summary>

```
All
  reverse
    32
      Bit: OK (0.66s)
        38.2 ns ± 2.7 ns
      C:   OK (0.67s)
        38.9 ns ± 718 ps, 1.02x
      SSE: OK (1.18s)
        34.1 ns ± 2.2 ns, 0.89x
      AVX: OK (0.30s)
        33.6 ns ± 1.7 ns, 0.88x
    64
      Bit: OK (0.22s)
        24.5 ns ± 1.4 ns
      C:   OK (0.31s)
        16.7 ns ± 692 ps, 0.68x
      SSE: OK (0.33s)
        18.5 ns ± 838 ps, 0.75x
      AVX: OK (0.34s)
        19.2 ns ± 1.0 ns, 0.78x
    128
      Bit: OK (0.28s)
        31.2 ns ± 2.0 ns
      C:   OK (0.35s)
        19.8 ns ± 968 ps, 0.64x
      SSE: OK (0.33s)
        18.7 ns ± 1.0 ns, 0.60x
      AVX: OK (0.41s)
        23.7 ns ± 960 ps, 0.76x
    256
      Bit: OK (0.43s)
        50.0 ns ± 2.2 ns
      C:   OK (0.24s)
        27.0 ns ± 2.3 ns, 0.54x
      SSE: OK (0.38s)
        21.4 ns ± 1.6 ns, 0.43x
      AVX: OK (0.36s)
        20.3 ns ± 1.7 ns, 0.41x
    512
      Bit: OK (0.35s)
        78.7 ns ± 3.9 ns
      C:   OK (0.36s)
        40.7 ns ± 2.2 ns, 0.52x
      SSE: OK (1.83s)
        26.9 ns ± 320 ps, 0.34x
      AVX: OK (0.21s)
        23.0 ns ± 1.8 ns, 0.29x
    1024
      Bit: OK (0.32s)
        145  ns ±  13 ns
      C:   OK (0.30s)
        68.0 ns ± 3.9 ns, 0.47x
      SSE: OK (0.35s)
        39.6 ns ± 1.8 ns, 0.27x
      AVX: OK (0.51s)
        28.9 ns ± 1.0 ns, 0.20x
    2048
      Bit: OK (0.31s)
        276  ns ±  19 ns
      C:   OK (0.27s)
        120  ns ± 9.0 ns, 0.44x
      SSE: OK (0.29s)
        64.4 ns ± 5.5 ns, 0.23x
      AVX: OK (0.38s)
        43.2 ns ± 3.6 ns, 0.16x
    4096
      Bit: OK (0.29s)
        519  ns ±  25 ns
      C:   OK (0.26s)
        234  ns ±  20 ns, 0.45x
      SSE: OK (0.26s)
        116  ns ± 8.4 ns, 0.22x
      AVX: OK (0.33s)
        73.3 ns ± 5.0 ns, 0.14x
    8192
      Bit: OK (0.57s)
        1.04 μs ±  41 ns
      C:   OK (0.25s)
        447  ns ±  27 ns, 0.43x
      SSE: OK (0.47s)
        214  ns ±  18 ns, 0.20x
      AVX: OK (0.55s)
        126  ns ± 6.1 ns, 0.12x
    16384
      Bit: OK (0.29s)
        2.06 μs ± 143 ns
      C:   OK (0.48s)
        873  ns ±  35 ns, 0.42x
      SSE: OK (0.46s)
        414  ns ±  16 ns, 0.20x
      AVX: OK (0.27s)
        242  ns ±  17 ns, 0.12x
```

</details>