### PR TITLE
Fix documentation for `selectBits` et al

### DIFF
--- a/src/Data/Bit/Immutable.hs
+++ b/src/Data/Bit/Immutable.hs
@@ -397,10 +397,10 @@ invertBits xs = runST $ do
     writeWord ys i (complement (indexWord xs i))
   U.unsafeFreeze ys
 
--- | For each set bit of the first argument, deposit
+-- | For each set bit of the first argument, extract
 -- the corresponding bit of the second argument
 -- to the result. Similar to the
--- [parallel bit deposit instruction (PDEP)](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set#Parallel_bit_deposit_and_extract).
+-- [parallel bit extract instruction (PEXT)](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set#Parallel_bit_deposit_and_extract).
 --
 -- >>> :set -XOverloadedLists
 -- >>> selectBits [0,1,0,1,1] [1,1,0,0,1]
@@ -418,7 +418,7 @@ selectBits is xs = runST $ do
   n   <- selectBitsInPlace is xs1
   U.unsafeFreeze (MU.take n xs1)
 
--- | For each unset bit of the first argument, deposit
+-- | For each unset bit of the first argument, extract
 -- the corresponding bit of the second argument
 -- to the result.
 --

--- a/src/Data/Bit/Mutable.hs
+++ b/src/Data/Bit/Mutable.hs
@@ -240,7 +240,7 @@ invertInPlace xs = do
     writeWord xs i (complement x)
 {-# SPECIALIZE invertInPlace :: U.MVector s Bit -> ST s () #-}
 
--- | Same as 'Data.Bit.selectBits', but deposit
+-- | Same as 'Data.Bit.selectBits', but extract
 -- selected bits in-place. Returns the number of selected bits.
 -- It is the caller's responsibility to trim the result to this number.
 --
@@ -265,7 +265,7 @@ selectBitsInPlace is xs = loop 0 0
       loop (i + wordSize) (ct + nSet)
 {-# SPECIALIZE selectBitsInPlace :: U.Vector Bit -> U.MVector s Bit -> ST s Int #-}
 
--- | Same as 'Data.Bit.excludeBits', but deposit
+-- | Same as 'Data.Bit.excludeBits', but extract
 -- excluded bits in-place. Returns the number of excluded bits.
 -- It is the caller's responsibility to trim the result to this number.
 --


### PR DESCRIPTION
The documentation said that `selectBits` works like PDEP, but it actually works like PEXT.