### PR TITLE
Use a pure FFI type for ompPopCount

### DIFF
--- a/src/Data/Bit/SIMD.hs
+++ b/src/Data/Bit/SIMD.hs
@@ -19,15 +19,14 @@ import Control.Monad.ST
 import Control.Monad.ST.Unsafe
 import Data.Primitive.ByteArray
 import GHC.Exts
-import System.IO.Unsafe
 
 foreign import ccall unsafe "_hs_bitvec_popcount"
-  omp_popcount :: ByteArray# -> Int# -> IO Int
+  omp_popcount :: ByteArray# -> Int# -> Int#
 
 -- | SIMD optimized popcount. The length is in 32 bit words.
 ompPopcount :: ByteArray -> Int -> Int
 ompPopcount (ByteArray arg#) (I# len#) =
-  unsafeDupablePerformIO (omp_popcount arg# len#)
+  I# (omp_popcount arg# len#)
 {-# INLINE ompPopcount #-}
 
 foreign import ccall unsafe "_hs_bitvec_com"


### PR DESCRIPTION
`ompPopCount` previously used a foreign call with a result in `IO`, wrapped in `unsafeDupablePerformIO`. Use a pure FFI call instead. Additionally, the `Int` argument to this function was previously unboxed manually but its result wasn't. I'm not sure how much difference it makes in practice, but uniformity is nice; unbox the result too.