### PR TITLE
Various zipBits improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # x.x.x.x
 
+* Make `zipBits` unconditionally strict in its second bit vector argument.
+
 * Add `simd` flag to use a C SIMD implementation for `zipBits`, `invertBits` and `countBits`,
   replacing the `libgmp` flag, and enable it by default.
 


### PR DESCRIPTION
1. Produce a run-time error if an inappropriate function is passed.
2. Use just one application of the user's function to determine the approprate SIMD implementation, by applying it to all four pairs at once.
3. Make `zipBits` unconditionally strict in its second bit vector argument.

Closes #74.
Closes #75.
Closes #76.