### PR TITLE
Implement `bitIndex` &`nthBitIndex` in C

### DIFF
--- a/src/Data/Bit/Immutable.hs
+++ b/src/Data/Bit/Immutable.hs
@@ -558,6 +558,11 @@ clipHiBits (Bit False) k w = w .|. hiMask k
 --
 -- @since 1.0.0.0
 bitIndex :: Bit -> U.Vector Bit -> Maybe Int
+#if UseSIMD
+bitIndex (Bit b) (BitVec 0 len arr) | modWordSize len == 0 =
+  let res = bitIndexC arr (divWordSize len) b
+  in if res < 0 then Nothing else Just res
+#endif
 bitIndex b (BitVec off len arr)
   | len == 0 = Nothing
   | offBits == 0 = case modWordSize len of
@@ -642,6 +647,11 @@ bitIndexInWords (Bit False) !off !len !arr = go off
 -- @since 1.0.0.0
 nthBitIndex :: Bit -> Int -> U.Vector Bit -> Maybe Int
 nthBitIndex _ k _ | k <= 0 = error "nthBitIndex: n must be positive"
+#if UseSIMD
+nthBitIndex (Bit b) n (BitVec 0 len arr) | modWordSize len == 0 =
+  let res = nthBitIndexC arr (divWordSize len) b n
+  in if res < 0 then Nothing else Just res
+#endif
 nthBitIndex b k (BitVec off len arr)
   | len == 0 = Nothing
   | offBits == 0 = either (const Nothing) Just $ case modWordSize len of

--- a/src/Data/Bit/SIMD.hs
+++ b/src/Data/Bit/SIMD.hs
@@ -13,10 +13,12 @@ module Data.Bit.SIMD
   , ompNior
   , ompXnor
   , reverseBitsC
+  , bitIndexC
+  , nthBitIndexC
   ) where
 
 import Control.Monad.ST
-import Control.Monad.ST.Unsafe
+import Control.Monad.ST.Unsafe (unsafeIOToST)
 import Data.Primitive.ByteArray
 import GHC.Exts
 
@@ -127,3 +129,19 @@ reverseBitsC :: MutableByteArray s -> ByteArray -> Int -> ST s ()
 reverseBitsC (MutableByteArray res#) (ByteArray arg#) (I# len#) =
   unsafeIOToST (reverse_bits res# arg# len#)
 {-# INLINE reverseBitsC #-}
+
+foreign import ccall unsafe "_hs_bitvec_bit_index"
+  bit_index :: ByteArray# -> Int# -> Bool -> Int#
+
+bitIndexC :: ByteArray -> Int -> Bool -> Int
+bitIndexC (ByteArray arg#) (I# len#) bit =
+  I# (bit_index arg# len# bit)
+{-# INLINE bitIndexC #-}
+
+foreign import ccall unsafe "_hs_bitvec_nth_bit_index"
+  nth_bit_index :: ByteArray# -> Int# -> Bool -> Int# -> Int#
+
+nthBitIndexC :: ByteArray -> Int -> Bool -> Int -> Int
+nthBitIndexC (ByteArray arg#) (I# len#) bit (I# n#) =
+  I# (nth_bit_index arg# len# bit n#)
+{-# INLINE nthBitIndexC #-}


### PR DESCRIPTION
`bitIndex` has an AVX version, an SSE version and a fallback version.
* C: 0.9x
* SSE: 0.7x
* AVX: 0.3x

`nthBitIndex` has a version using `popcnt` and a fallback version.
* C: 0.6x
* popcnt: 0.2x

I also wrote `nthBitIndex` versions using SSE/AVX/`pdep`, but those didn't show any big improvements and were more complicated, so I left them out.

For some reason, adding/removing C functions changed the benchmark results (up to 100 ns), but the improvements should be somewhat accurate.