### PR TITLE
Implement `selectBits` & `excludeBits` in C

### DIFF
--- a/src/Data/Bit/Immutable.hs
+++ b/src/Data/Bit/Immutable.hs
@@ -480,6 +480,14 @@ invertBits xs = runST $ do
 --
 -- @since 0.1
 selectBits :: U.Vector Bit -> U.Vector Bit -> U.Vector Bit
+#ifdef UseSIMD
+selectBits (BitVec 0 iLen iArr) (BitVec 0 xLen xArr) | modWordSize len == 0 = runST $ do
+  marr <- newByteArray (len `shiftR` 3)
+  n <- selectBitsC marr xArr iArr (divWordSize len) False
+  BitVec 0 n <$> unsafeFreezeByteArray marr
+ where
+  len = min iLen xLen
+#endif
 selectBits is xs = runST $ do
   xs1 <- U.thaw xs
   n   <- selectBitsInPlace is xs1
@@ -502,6 +510,14 @@ selectBits is xs = runST $ do
 --
 -- @since 0.1
 excludeBits :: U.Vector Bit -> U.Vector Bit -> U.Vector Bit
+#ifdef UseSIMD
+excludeBits (BitVec 0 iLen iArr) (BitVec 0 xLen xArr) | modWordSize len == 0 = runST $ do
+  marr <- newByteArray (len `shiftR` 3)
+  n <- selectBitsC marr xArr iArr (divWordSize len) True
+  BitVec 0 n <$> unsafeFreezeByteArray marr
+ where
+  len = min iLen xLen
+#endif
 excludeBits is xs = runST $ do
   xs1 <- U.thaw xs
   n   <- excludeBitsInPlace is xs1

--- a/src/Data/Bit/SIMD.hs
+++ b/src/Data/Bit/SIMD.hs
@@ -15,6 +15,7 @@ module Data.Bit.SIMD
   , reverseBitsC
   , bitIndexC
   , nthBitIndexC
+  , selectBitsC
   ) where
 
 import Control.Monad.ST
@@ -145,3 +146,11 @@ nthBitIndexC :: ByteArray -> Int -> Bool -> Int -> Int
 nthBitIndexC (ByteArray arg#) (I# len#) bit (I# n#) =
   I# (nth_bit_index arg# len# bit n#)
 {-# INLINE nthBitIndexC #-}
+
+foreign import ccall unsafe "_hs_bitvec_select_bits"
+  select_bits_c :: MutableByteArray# s -> ByteArray# -> ByteArray# -> Int# -> Bool -> IO Int
+
+selectBitsC :: MutableByteArray s -> ByteArray -> ByteArray -> Int -> Bool -> ST s Int
+selectBitsC (MutableByteArray res#) (ByteArray arg1#) (ByteArray arg2#) (I# len#) exclude =
+  unsafeIOToST (select_bits_c res# arg1# arg2# len# exclude)
+{-# INLINE selectBitsC #-}

--- a/test/Tests/SetOps.hs
+++ b/test/Tests/SetOps.hs
@@ -41,15 +41,15 @@ setOpTests = testGroup "Set operations"
   , testProperty "invertInPlace middle"     prop_invertInPlace_middle
   , testProperty "invertInPlaceLong middle" prop_invertInPlaceLong_middle
 
-  , adjustOption (\n -> max 500 n :: QuickCheckTests) $ mkGroup "reverseBits" prop_reverseBits
+  , mkGroup "reverseBits" prop_reverseBits
 
   , testProperty "reverseInPlace"            prop_reverseInPlace
   , testProperty "reverseInPlaceWords"       prop_reverseInPlaceWords
   , testProperty "reverseInPlace middle"     prop_reverseInPlace_middle
   , testProperty "reverseInPlaceLong middle" prop_reverseInPlaceLong_middle
 
-  , adjustOption (\n -> max 500 n :: QuickCheckTests) $ mkGroup2 "selectBits" prop_selectBits_def
-  , adjustOption (\n -> max 500 n :: QuickCheckTests) $ mkGroup2 "excludeBits" prop_excludeBits_def
+  , mkGroup2 "selectBits"  prop_selectBits_def
+  , mkGroup2 "excludeBits" prop_excludeBits_def
 
   , mkGroup "countBits" prop_countBits_def
   ]


### PR DESCRIPTION
Add a version using `popcnt`/`pext` (0.01x) and a fallback C version (0.15x).

I also had SSE and AVX versions, but those had ugly code duplication (making them long and error prone) and the `pext` version is faster anyway.